### PR TITLE
Route for registering problems with deliveries

### DIFF
--- a/src/app/controllers/CancelController.js
+++ b/src/app/controllers/CancelController.js
@@ -1,0 +1,33 @@
+import Problem from '../models/Problem';
+import Delivery from '../models/Delivery';
+
+class CancelController {
+  async delete(req, res) {
+    const { problem_id } = req.params;
+
+    const problem = await Problem.findByPk(problem_id);
+
+    const delivery_id = problem.delivery_id;
+
+    const { cancelled_at } = await Delivery.findByPk(delivery_id);
+
+    if (cancelled_at) {
+      return res
+        .status(400)
+        .json({ error: `Delivery ${delivery_id} already cancelled` });
+    }
+
+    await Delivery.update(
+      { cancelled_at: new Date() },
+      { where: { id: delivery_id } }
+    );
+
+    const updatedDelivery = await Delivery.findByPk(delivery_id, {
+      attributes: ['id', 'product', 'start_date', 'cancelled_at'],
+    });
+
+    return res.json({ problem, delivery: updatedDelivery });
+  }
+}
+
+export default new CancelController();

--- a/src/app/controllers/ProblemController.js
+++ b/src/app/controllers/ProblemController.js
@@ -28,6 +28,14 @@ class ProblemController {
 
     return res.json(problem);
   }
+
+  async index(req, res) {
+    const { delivery_id } = req.params;
+
+    const problems = await Problem.findAll({ where: { delivery_id }, include });
+
+    return res.json({ problems });
+  }
 }
 
 export default new ProblemController();

--- a/src/app/controllers/ProblemController.js
+++ b/src/app/controllers/ProblemController.js
@@ -1,0 +1,33 @@
+import * as Yup from 'yup';
+
+import Problem from '../models/Problem';
+import Delivery from '../models/Delivery';
+
+const include = {
+  model: Delivery,
+  as: 'delivery',
+  attributes: ['id', 'start_date', 'end_date'],
+};
+
+class ProblemController {
+  async store(req, res) {
+    const schema = Yup.object().shape({
+      description: Yup.string().required(),
+    });
+
+    if (!(await schema.isValid(req.body))) {
+      return res.status(400).json({ error: 'Input validation failed' });
+    }
+
+    const { delivery_id } = req.params;
+    const { description } = req.body;
+
+    const { id } = await Problem.create({ delivery_id, description });
+
+    const problem = await Problem.findByPk(id, { include });
+
+    return res.json(problem);
+  }
+}
+
+export default new ProblemController();

--- a/src/app/models/Problem.js
+++ b/src/app/models/Problem.js
@@ -1,0 +1,26 @@
+import Sequelize, { Model } from 'sequelize';
+
+class Problem extends Model {
+  static init(sequelize) {
+    super.init(
+      {
+        description: Sequelize.STRING,
+        delivery_id: Sequelize.INTEGER,
+      },
+      {
+        sequelize,
+      }
+    );
+
+    return this;
+  }
+
+  static associate(models) {
+    this.belongsTo(models.Recipient, {
+      foreignKey: 'delivery_id',
+      as: 'delivery',
+    });
+  }
+}
+
+export default Problem;

--- a/src/app/models/Problem.js
+++ b/src/app/models/Problem.js
@@ -16,7 +16,7 @@ class Problem extends Model {
   }
 
   static associate(models) {
-    this.belongsTo(models.Recipient, {
+    this.belongsTo(models.Delivery, {
       foreignKey: 'delivery_id',
       as: 'delivery',
     });

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -4,11 +4,12 @@ import User from '../app/models/User';
 import Recipient from '../app/models/Recipient';
 import Deliveryman from '../app/models/Deliveryman';
 import Delivery from '../app/models/Delivery';
+import Problem from '../app/models/Problem';
 import File from '../app/models/File';
 
 import databaseConfig from '../config/database';
 
-const models = [User, Recipient, Deliveryman, Delivery, File];
+const models = [User, Recipient, Deliveryman, Delivery, Problem, File];
 
 class Database {
   constructor() {

--- a/src/database/migrations/20200324162728-create-problems.js
+++ b/src/database/migrations/20200324162728-create-problems.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('problems', {
+      id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      description: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      delivery_id: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'deliveries',
+          key: 'id',
+        },
+        allowNull: false,
+        onUpdate: 'CASCADE',
+        onDelete: 'RESTRICT',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('problems');
+  },
+};

--- a/src/restclient/cancel.restclient
+++ b/src/restclient/cancel.restclient
@@ -1,0 +1,1 @@
+DELETE http://localhost:3333/problem/7/cancel-delivery

--- a/src/restclient/delivery.restclient
+++ b/src/restclient/delivery.restclient
@@ -6,4 +6,3 @@ Content-Type: application/json
 
 # finish delivery
 POST http://localhost:3333/delivery/18/finish
-

--- a/src/restclient/problem.restclient
+++ b/src/restclient/problem.restclient
@@ -1,0 +1,5 @@
+# register problem
+POST http://localhost:3333/delivery/18/problem
+Content-Type: application/json
+
+{"description": "problema grave"}

--- a/src/restclient/problem.restclient
+++ b/src/restclient/problem.restclient
@@ -2,4 +2,7 @@
 POST http://localhost:3333/delivery/18/problem
 Content-Type: application/json
 
-{"description": "problema grave"}
+{"description": "big problem"}
+
+# list problems
+GET http://localhost:3333/delivery/18/problem

--- a/src/routes.js
+++ b/src/routes.js
@@ -11,6 +11,7 @@ import DeliveryController from './app/controllers/DeliveryController';
 import StartDeliveryController from './app/controllers/StartDeliveryController';
 import FinishDeliveryController from './app/controllers/FinishDeliveryController';
 import ProblemController from './app/controllers/ProblemController';
+import CancelController from './app/controllers/CancelController';
 import FileController from './app/controllers/FileController';
 
 import authMiddleware from './app/middlewares/auth';
@@ -26,6 +27,8 @@ routes.post('/delivery/:delivery_id/finish', FinishDeliveryController.store);
 
 routes.post('/delivery/:delivery_id/problem', ProblemController.store);
 routes.get('/delivery/:delivery_id/problem', ProblemController.index);
+
+routes.delete('/problem/:problem_id/cancel-delivery', CancelController.delete);
 
 routes.use(authMiddleware);
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -10,6 +10,7 @@ import DeliverymanController from './app/controllers/DeliverymanController';
 import DeliveryController from './app/controllers/DeliveryController';
 import StartDeliveryController from './app/controllers/StartDeliveryController';
 import FinishDeliveryController from './app/controllers/FinishDeliveryController';
+import ProblemController from './app/controllers/ProblemController';
 import FileController from './app/controllers/FileController';
 
 import authMiddleware from './app/middlewares/auth';
@@ -22,6 +23,8 @@ routes.post('/sessions', SessionController.store);
 
 routes.post('/delivery/:delivery_id/start', StartDeliveryController.store);
 routes.post('/delivery/:delivery_id/finish', FinishDeliveryController.store);
+
+routes.post('/delivery/:delivery_id/problem', ProblemController.store);
 
 routes.use(authMiddleware);
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -25,6 +25,7 @@ routes.post('/delivery/:delivery_id/start', StartDeliveryController.store);
 routes.post('/delivery/:delivery_id/finish', FinishDeliveryController.store);
 
 routes.post('/delivery/:delivery_id/problem', ProblemController.store);
+routes.get('/delivery/:delivery_id/problem', ProblemController.index);
 
 routes.use(authMiddleware);
 


### PR DESCRIPTION
There should be a route to register a problem with the delivery, in the case the deliveryman was unable to accomplish it. The delivery problems table must have the following fields.

- delivery_id
- description
- created_at
- updated_at

The routes below should be implemented:
- List all the  problemas associated with a delivery
GET https://fastfeet.com/delivery/2/problems

- Register a problem for a delivery
POST https://fastfeet.com/delivery/3/problems

- Cancel delivery, for problems with no solution (for instance, the lost of a package)
DELETE https://fastfeet.com/problem/1/cancel-delivery